### PR TITLE
hotfix docker-compose unsupported target

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.7'
 services:
   client:
     restart: always


### PR DESCRIPTION
Fix following error that prevents to run `docker-composer` at all:
```
docker-compose run --rm client npm install
ERROR: The Compose file './docker-compose.yml' is invalid because:
services.client.build contains unsupported option: 'target'
services.server.build contains unsupported option: 'target'
make: *** [Makefile:4: install] Errore 1
```

Also, I am stuck into this step of `make install`:
```
Step 14/15 : RUN npm run build
 ---> Running in f1b855bc3a6d
npm ERR! Missing script: "build"
npm ERR! 
npm ERR! To see a list of scripts, run:
npm ERR!   npm run

npm ERR! A complete log of this run can be found in:
npm ERR!     /root/.npm/_logs/2021-08-28T09_22_49_926Z-debug.log
ERROR: Service 'server' failed to build: The command '/bin/sh -c npm run build' returned a non-zero code: 1
make: *** [Makefile:5: install] Errore 1
```